### PR TITLE
Add -device argument so that user can control which battery device to monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ A simple tool to give you Desktop Notifications about your battery, requires UPo
 $ upower-notify --help
 
 Usage of upower-notify:
-  -critical=10m0s: Time to start warning. (Critical)
-  -report=false: Print out updates to stdout.
-  -tick=10s: Update rate
-  -warn=20m0s: Time to start warning. (Warn)
+  -critical duration
+    	Time to start warning. (Critical) (default 10m0s)
+  -device string
+    	DBus address of the battery device (default "/org/freedesktop/UPower/devices/battery_BAT0")
+  -report
+    	Print out updates to stdout.
+  -tick duration
+    	Update rate (default 10s)
+  -warn duration
+    	Time to start warning. (Warn) (default 20m0s)
 ```
 
 if you're using `i3wm` or relatives, just chuck this or it's equalent in your startup script:

--- a/main.go
+++ b/main.go
@@ -25,11 +25,11 @@ var (
 
 func main() {
 
-	flag.DurationVar(&tick,     "tick",     10*time.Second,                                  "Update rate")
-	flag.DurationVar(&warn,     "warn",     20*time.Minute,                                  "Time to start warning. (Warn)")
-	flag.DurationVar(&critical, "critical", 10*time.Minute,                                  "Time to start warning. (Critical)")
-	flag.StringVar(  &device,   "device",   "/org/freedesktop/UPower/devices/DisplayDevice", "DBus address of the battery device")
-	flag.BoolVar(    &report,   "report",   false,                                           "Print out updates to stdout.")
+	flag.DurationVar(&tick,     "tick",     10*time.Second,  "Update rate")
+	flag.DurationVar(&warn,     "warn",     20*time.Minute,  "Time to start warning. (Warn)")
+	flag.DurationVar(&critical, "critical", 10*time.Minute,  "Time to start warning. (Critical)")
+	flag.StringVar(  &device,   "device",   "DisplayDevice", "DBus device name for the battery")
+	flag.BoolVar(    &report,   "report",   false,           "Print out updates to stdout.")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -25,11 +25,11 @@ var (
 
 func main() {
 
-	flag.DurationVar(&tick,     "tick",     10*time.Second,                                 "Update rate")
-	flag.DurationVar(&warn,     "warn",     20*time.Minute,                                 "Time to start warning. (Warn)")
-	flag.DurationVar(&critical, "critical", 10*time.Minute,                                 "Time to start warning. (Critical)")
-	flag.StringVar(  &device,   "device",   "/org/freedesktop/UPower/devices/battery_BAT0", "DBus address of the battery device")
-	flag.BoolVar(    &report,   "report",   false,                                          "Print out updates to stdout.")
+	flag.DurationVar(&tick,     "tick",     10*time.Second,                                  "Update rate")
+	flag.DurationVar(&warn,     "warn",     20*time.Minute,                                  "Time to start warning. (Warn)")
+	flag.DurationVar(&critical, "critical", 10*time.Minute,                                  "Time to start warning. (Critical)")
+	flag.StringVar(  &device,   "device",   "/org/freedesktop/UPower/devices/DisplayDevice", "DBus address of the battery device")
+	flag.BoolVar(    &report,   "report",   false,                                           "Print out updates to stdout.")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -19,19 +19,21 @@ var (
 	tick     time.Duration
 	warn     time.Duration
 	critical time.Duration
+	device   string
 	report   bool
 )
 
 func main() {
 
-	flag.DurationVar(&tick, "tick", 10*time.Second, "Update rate")
-	flag.DurationVar(&warn, "warn", 20*time.Minute, "Time to start warning. (Warn)")
-	flag.DurationVar(&critical, "critical", 10*time.Minute, "Time to start warning. (Critical)")
-	flag.BoolVar(&report, "report", false, "Print out updates to stdout.")
+	flag.DurationVar(&tick,     "tick",     10*time.Second,                                 "Update rate")
+	flag.DurationVar(&warn,     "warn",     20*time.Minute,                                 "Time to start warning. (Warn)")
+	flag.DurationVar(&critical, "critical", 10*time.Minute,                                 "Time to start warning. (Critical)")
+	flag.StringVar(  &device,   "device",   "/org/freedesktop/UPower/devices/battery_BAT0", "DBus address of the battery device")
+	flag.BoolVar(    &report,   "report",   false,                                          "Print out updates to stdout.")
 
 	flag.Parse()
 
-	up, err := upower.New()
+	up, err := upower.New(device)
 
 	if err != nil {
 		log.Fatal(err)

--- a/upower/upower.go
+++ b/upower/upower.go
@@ -184,7 +184,8 @@ func New(device string) (*UPower, error) {
 		return nil, err
 	}
 
-	up := conn.Object("org.freedesktop.UPower", dbus.ObjectPath(device))
+	path := dbus.ObjectPath("/org/freedesktop/UPower/devices/" + device)
+	up := conn.Object("org.freedesktop.UPower", path)
 	if up == nil {
 		return nil, NoUpower
 	}

--- a/upower/upower.go
+++ b/upower/upower.go
@@ -179,14 +179,14 @@ func (s *Update) Changed(old Update) bool {
 
 }
 
-func New() (*UPower, error) {
+func New(device string) (*UPower, error) {
 
 	conn, err := dbus.SystemBus()
 	if err != nil {
 		return nil, err
 	}
 
-	up := conn.Object("org.freedesktop.UPower", "/org/freedesktop/UPower/devices/battery_BAT0")
+	up := conn.Object("org.freedesktop.UPower", dbus.ObjectPath(device))
 	if up == nil {
 		return nil, NoUpower
 	}

--- a/upower/upower.go
+++ b/upower/upower.go
@@ -3,8 +3,6 @@
 // A minimal binding for UPower over DBUS.
 // it is designed to be as simple as possible.
 
-//TODO: Perhaps using DisplayDevice is better than BAT0 from /org/freedesktop/UPower/devices/
-
 package upower
 
 import (


### PR DESCRIPTION
As discussed in https://github.com/omeid/upower-notify/issues/1
